### PR TITLE
Update CI workflow for Python 3.11

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,24 +19,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install pytest ruff
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
     - name: Set PYTHONPATH
       run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
-    - name: Lint with flake8
+    - name: Lint with Ruff
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # Aligns with previous flake8 gate by checking only fatal error codes
+        ruff check . --select E9,F63,F7,F82
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
### **User description**
## Summary
- update the python-app GitHub Actions workflow to provision Python 3.11 with the latest setup-python action
- align linting with Ruff by installing it in CI and checking for fatal error codes

## Testing
- ruff check . --select E9,F63,F7,F82
- PYTHONPATH=$(pwd) pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca5f4aaf5c832db4f6ab15d7565978


___

### **PR Type**
Enhancement


___

### **Description**
- Upgrade Python version from 3.10 to 3.11

- Replace flake8 with Ruff for linting

- Update setup-python action to v5

- Streamline CI workflow configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Python 3.10"] --> B["Python 3.11"]
  C["flake8"] --> D["Ruff"]
  E["setup-python@v3"] --> F["setup-python@v5"]
  B --> G["Updated CI Workflow"]
  D --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python-app.yml</strong><dd><code>Modernize CI workflow with Python 3.11 and Ruff</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/python-app.yml

<ul><li>Updated Python version from 3.10 to 3.11<br> <li> Upgraded setup-python action from v3 to v5<br> <li> Replaced flake8 with Ruff for linting<br> <li> Simplified linting configuration to check only fatal error codes</ul>


</details>


  </td>
  <td><a href="https://github.com/dawsonblock/Liquid-Capsule-Brain/pull/11/files#diff-d7b3e1cc0b909c52439e5d8d3f602f70644d0f6b62a54825968d819f7a5bee89">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

