### PR TITLE
Adjust overseer graph edge payload and add regression test

### DIFF
--- a/teacher/ai_overseer.py
+++ b/teacher/ai_overseer.py
@@ -1,34 +1,69 @@
-import asyncio, json, logging
-from typing import Any, Dict
-import httpx, yaml
+import asyncio
+import logging
+from typing import Any, cast
+
+import httpx
+import yaml
+
 log = logging.getLogger(__name__)
 
+
 class AIOverseer:
-    def __init__(self, config_path: str, student_api_host: str = "http://localhost:8000"):
+    def __init__(self, config_path: str, student_api_host: str = "http://localhost:8000") -> None:
         self.student_api_host = student_api_host
-        self.config = yaml.safe_load(open(config_path, 'r'))['ai_overseer_config']
+        with open(config_path, encoding="utf-8") as config_file:
+            config: dict[str, Any] = yaml.safe_load(config_file)
+            self.config = config["ai_overseer_config"]
         self.http_client = httpx.AsyncClient(timeout=180.0)
-    async def assess_student_state(self) -> Dict[str, Any]:
-        r = await self.http_client.get(f"{self.student_api_host}/state/summary"); r.raise_for_status(); return r.json()
-    async def plan_next_action(self, student_state: Dict[str, Any]) -> Dict[str, Any]:
-        phi = float(student_state.get("self_awareness_metrics",{}).get("phi",0.0))
-        if phi < 1.0: return {"action":"reasoning_probe","question":"How does entropy in thermodynamics relate to technical debt in software systems?"}
-        return {"action":"graph_synthesis","source_node":"attention","relation":"related_to","target_node":"knowledge_integration"}
-    async def execute_action(self, plan: Dict[str, Any]):
-        a=plan.get("action")
-        if a=="reasoning_probe":
-            await self.http_client.post(f"{self.student_api_host}/ask", json={"q": plan["question"]})
-        elif a=="knowledge_injection":
-            prompt=f"Research '{plan['topic']}' using your tools and summarize the key findings."
-            await self.http_client.post(f"{self.student_api_host}/ask", json={"q": prompt})
-        elif a=="graph_synthesis":
-            await self.http_client.post(f"{self.student_api_host}/graph/edge", params=plan)
-    async def run_supervisory_loop(self, num_cycles: int = 5):
+
+    async def assess_student_state(self) -> dict[str, Any]:
+        response = await self.http_client.get(f"{self.student_api_host}/state/summary")
+        response.raise_for_status()
+        return cast(dict[str, Any], response.json())
+
+    async def plan_next_action(self, student_state: dict[str, Any]) -> dict[str, Any]:
+        phi = float(student_state.get("self_awareness_metrics", {}).get("phi", 0.0))
+        if phi < 1.0:
+            return {
+                "action": "reasoning_probe",
+                "question": "How does entropy in thermodynamics relate to technical debt in software systems?",
+            }
+        return {
+            "action": "graph_synthesis",
+            "source": "attention",
+            "relation": "related_to",
+            "target": "knowledge_integration",
+        }
+
+    async def execute_action(self, plan: dict[str, Any]) -> None:
+        action = plan.get("action")
+        if action == "reasoning_probe":
+            await self.http_client.post(
+                f"{self.student_api_host}/ask",
+                json={"q": plan["question"]},
+            )
+        elif action == "knowledge_injection":
+            prompt = f"Research '{plan['topic']}' using your tools and summarize the key findings."
+            await self.http_client.post(
+                f"{self.student_api_host}/ask",
+                json={"q": prompt},
+            )
+        elif action == "graph_synthesis":
+            params = {key: plan[key] for key in ("source", "target") if key in plan}
+            if "relation" in plan:
+                params["relation"] = plan["relation"]
+            await self.http_client.post(
+                f"{self.student_api_host}/graph/edge",
+                params=params,
+            )
+
+    async def run_supervisory_loop(self, num_cycles: int = 5) -> None:
         for _ in range(num_cycles):
             try:
-                s = await self.assess_student_state()
-                plan = await self.plan_next_action(s)
+                student_state = await self.assess_student_state()
+                plan = await self.plan_next_action(student_state)
                 await self.execute_action(plan)
                 await asyncio.sleep(5)
-            except Exception as e:
-                log.error(f"Overseer cycle error: {e}"); await asyncio.sleep(5)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                log.error("Overseer cycle error: %s", exc)
+                await asyncio.sleep(5)

--- a/teacher/overseer_config.yaml
+++ b/teacher/overseer_config.yaml
@@ -7,4 +7,4 @@ ai_overseer_config:
     Choose ONE action and respond ONLY as JSON using one of:
     {"action":"reasoning_probe","question":"Which subsystem limits p95 response time and what is the simplest change to improve it?"}
     {"action":"knowledge_injection","topic":"retrieval-augmented generation evaluation best practices"}
-    {"action":"graph_synthesis","source_node":"planner","relation":"related_to","target_node":"retrieval"}
+    {"action":"graph_synthesis","source":"planner","relation":"related_to","target":"retrieval"}

--- a/tests/test_overseer.py
+++ b/tests/test_overseer.py
@@ -1,0 +1,43 @@
+from typing import Any, cast
+
+import httpx
+import pytest
+
+from capsule_brain.api import server
+from capsule_brain.core.capsule_engine import CapsuleEngine
+from teacher.ai_overseer import AIOverseer
+
+
+@pytest.mark.asyncio
+async def test_overseer_can_add_graph_edge() -> None:
+    overseer = AIOverseer("teacher/overseer_config.yaml", student_api_host="http://test")
+    await overseer.http_client.aclose()
+
+    transport = httpx.ASGITransport(app=cast(Any, server.app))
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        overseer.http_client = client
+
+        previous_engine = server.engine
+        engine = CapsuleEngine()
+        await engine.start_background_tasks()
+        server.engine = engine
+
+        try:
+            student_state = await overseer.assess_student_state()
+            student_state.setdefault("self_awareness_metrics", {})["phi"] = 1.5
+
+            plan = await overseer.plan_next_action(student_state)
+            assert plan["action"] == "graph_synthesis"
+            assert {"source", "target"}.issubset(plan)
+            assert plan.get("relation") == "related_to"
+
+            await overseer.execute_action(plan)
+
+            assert server.engine is not None
+            graph = server.engine.knowledge_graph
+            assert graph.has_edge(plan["source"], plan["target"])
+            edge_data = graph.get_edge_data(plan["source"], plan["target"])
+            assert edge_data.get("relation") == plan["relation"]
+        finally:
+            await engine.shutdown()
+            server.engine = previous_engine


### PR DESCRIPTION
### **User description**
## Summary
- update the AI overseer to emit `source`/`target` graph keys, drop the `/graph/edge` action param, and tidy the module structure
- refresh the overseer prompt config to reflect the new graph key names
- add an async regression test that exercises the overseer loop and verifies an edge can be added without validation errors

## Testing
- PYTHONPATH=. pytest
- ruff check teacher/ai_overseer.py tests/test_overseer.py
- PYTHONPATH=. mypy teacher
- PYTHONPATH=. mypy tests/test_overseer.py

------
https://chatgpt.com/codex/tasks/task_e_68ca5f7fd320832da6f28dfa0c697448


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor AI overseer to use `source`/`target` keys instead of `source_node`/`target_node`

- Add comprehensive async regression test for overseer functionality

- Improve code quality with type hints and formatting

- Update configuration to match new graph key structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AI Overseer"] -- "refactored payload" --> B["Graph Edge API"]
  C["Test Suite"] -- "validates" --> A
  D["Config File"] -- "updated keys" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai_overseer.py</strong><dd><code>Refactor overseer with new graph keys and type safety</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

teacher/ai_overseer.py

<ul><li>Replace <code>source_node</code>/<code>target_node</code> with <code>source</code>/<code>target</code> in graph synthesis <br>action<br> <li> Add comprehensive type hints and improve code formatting<br> <li> Refactor HTTP client usage and error handling<br> <li> Clean up imports and add proper encoding for file operations</ul>


</details>


  </td>
  <td><a href="https://github.com/dawsonblock/Liquid-Capsule-Brain/pull/20/files#diff-965b3b4cedca4225cceae58a4219b43098039db9c2c20245263e540bfa5da845">+60/-25</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_overseer.py</strong><dd><code>Add comprehensive overseer regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_overseer.py

<ul><li>Add new async test for overseer graph edge functionality<br> <li> Test complete overseer loop including state assessment and action <br>execution<br> <li> Verify graph edge creation with proper validation<br> <li> Use ASGI transport for testing HTTP interactions</ul>


</details>


  </td>
  <td><a href="https://github.com/dawsonblock/Liquid-Capsule-Brain/pull/20/files#diff-acc9f1d9638b677063584095029f6fdb1ca999d1964ea7b09ccd43ff0ba0c57e">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>overseer_config.yaml</strong><dd><code>Update config to match new graph key names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

teacher/overseer_config.yaml

<ul><li>Update strategic planner prompt to use <code>source</code>/<code>target</code> instead of <br><code>source_node</code>/<code>target_node</code><br> <li> Maintain consistency with refactored overseer implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/dawsonblock/Liquid-Capsule-Brain/pull/20/files#diff-36db6a16590ecab75eb29b67dc4e58c6b54ba6ee04fc0b5497d7b198d458627b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

