### PR TITLE
Support JSON body in /ask endpoint

### DIFF
--- a/capsule_brain/api/server.py
+++ b/capsule_brain/api/server.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Any
 
-from fastapi import Body, FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, Field, ValidationError
 
 from capsule_brain.core.capsule_engine import CapsuleEngine
 from capsule_brain.observability.metrics import MetricsMiddleware
@@ -19,21 +19,15 @@ app.add_middleware(MetricsMiddleware)
 app.include_router(metrics_router)
 
 engine: CapsuleEngine | None = None
-ASK_REQUEST_BODY = Body(default=None)
 ASK_QUERY_PARAM = Query(default=None)
 
 
 class AskRequest(BaseModel):
     """Payload accepted by the /ask endpoint."""
 
-    question: str | None = Field(default=None, alias="q")
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    def extract(self) -> str | None:
-        """Return the provided question regardless of the key used."""
-
-        return self.question
+    question: str | None = Field(
+        default=None, validation_alias=AliasChoices("question", "q")
+    )
 
 @app.on_event("startup")
 async def on_startup() -> None:
@@ -63,15 +57,41 @@ async def state_summary() -> dict[str, Any]:
     return engine.get_state_summary()
 
 @app.post("/ask")
-async def ask(
-    ask_request: AskRequest | None = ASK_REQUEST_BODY,
-    q: str | None = ASK_QUERY_PARAM,
-) -> dict[str, Any]:
+async def ask(request: Request, q: str | None = ASK_QUERY_PARAM) -> dict[str, Any]:
     if not engine:
         raise HTTPException(status_code=503, detail="engine not ready")
     assert engine is not None
     current_engine = engine
-    question = ask_request.extract() if ask_request else None
+    question: str | None = None
+    if question is None:
+        try:
+            raw_payload = await request.json()
+        except ValueError:
+            raw_payload = None
+        if isinstance(raw_payload, dict):
+            try:
+                question = AskRequest.model_validate(raw_payload).question
+            except ValidationError:
+                question = None
+        elif isinstance(raw_payload, str):
+            question = raw_payload
+    if question is None:
+        try:
+            form = await request.form()
+        except Exception:  # pragma: no cover - defensive guard
+            form = None
+        if form is not None:
+            form_q = form.get("q") or form.get("question")
+            if isinstance(form_q, str):
+                question = form_q
+    if question is None:
+        content_type = request.headers.get("content-type", "")
+        if "text/plain" in content_type or not content_type:
+            body_bytes = await request.body()
+            if body_bytes:
+                candidate = body_bytes.decode("utf-8", errors="ignore").strip()
+                if candidate:
+                    question = candidate
     if question is None:
         question = q
     if question is None:

--- a/capsule_brain/api/server.py
+++ b/capsule_brain/api/server.py
@@ -1,9 +1,13 @@
-import asyncio, logging, os
-from typing import Dict, Any
-from fastapi import FastAPI, HTTPException
+import logging
+from typing import Any
+
+from fastapi import Body, FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, ConfigDict, Field
+
 from capsule_brain.core.capsule_engine import CapsuleEngine
-from capsule_brain.observability.metrics import router as metrics_router, MetricsMiddleware
+from capsule_brain.observability.metrics import MetricsMiddleware
+from capsule_brain.observability.metrics import router as metrics_router
 
 log = logging.getLogger(__name__)
 app = FastAPI(title="Capsule Brain Supreme AGI", version="1.0.1")
@@ -15,41 +19,77 @@ app.add_middleware(MetricsMiddleware)
 app.include_router(metrics_router)
 
 engine: CapsuleEngine | None = None
+ASK_REQUEST_BODY = Body(default=None)
+ASK_QUERY_PARAM = Query(default=None)
+
+
+class AskRequest(BaseModel):
+    """Payload accepted by the /ask endpoint."""
+
+    question: str | None = Field(default=None, alias="q")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    def extract(self) -> str | None:
+        """Return the provided question regardless of the key used."""
+
+        return self.question
 
 @app.on_event("startup")
-async def on_startup():
+async def on_startup() -> None:
     global engine
     engine = CapsuleEngine()
     await engine.start_background_tasks()
     log.info("Engine started.")
 
 @app.on_event("shutdown")
-async def on_shutdown():
+async def on_shutdown() -> None:
     if engine:
         await engine.shutdown()
 
 @app.get("/healthz")
-async def healthz() -> Dict[str, Any]:
+async def healthz() -> dict[str, Any]:
     return {"ok": True}
 
 @app.get("/ready")
-async def ready() -> Dict[str, Any]:
+async def ready() -> dict[str, Any]:
     return {"ready": engine is not None}
 
 @app.get("/state/summary")
-async def state_summary() -> Dict[str, Any]:
-    if not engine: raise HTTPException(status_code=503, detail="engine not ready")
+async def state_summary() -> dict[str, Any]:
+    if not engine:
+        raise HTTPException(status_code=503, detail="engine not ready")
+    assert engine is not None
     return engine.get_state_summary()
 
 @app.post("/ask")
-async def ask(q: str) -> Dict[str, Any]:
-    if not engine: raise HTTPException(status_code=503, detail="engine not ready")
-    engine.add_memory("user", q)
-    context, system_prompt = engine.belief_state_manager.synthesize_context_for_llm()
+async def ask(
+    ask_request: AskRequest | None = ASK_REQUEST_BODY,
+    q: str | None = ASK_QUERY_PARAM,
+) -> dict[str, Any]:
+    if not engine:
+        raise HTTPException(status_code=503, detail="engine not ready")
+    assert engine is not None
+    current_engine = engine
+    question = ask_request.extract() if ask_request else None
+    if question is None:
+        question = q
+    if question is None:
+        raise HTTPException(status_code=422, detail="q is required")
+    current_engine.add_memory("user", question)
+    context, system_prompt = current_engine.belief_state_manager.synthesize_context_for_llm()
     return {"ack": True, "context": context, "system": system_prompt}
 
 @app.post("/graph/edge")
-async def add_edge(source: str, target: str, relation: str = "related_to") -> Dict[str, Any]:
-    if not engine: raise HTTPException(status_code=503, detail="engine not ready")
+async def add_edge(source: str, target: str, relation: str = "related_to") -> dict[str, Any]:
+    if not engine:
+        raise HTTPException(status_code=503, detail="engine not ready")
+    assert engine is not None
     engine.add_graph_edge(source, target, relation)
-    return {"ok": True, "graph": {"nodes": engine.knowledge_graph.number_of_nodes(), "edges": engine.knowledge_graph.number_of_edges()}}
+    return {
+        "ok": True,
+        "graph": {
+            "nodes": engine.knowledge_graph.number_of_nodes(),
+            "edges": engine.knowledge_graph.number_of_edges(),
+        },
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,15 +1,20 @@
-from fastapi.testclient import TestClient
-from capsule_brain.api.server import app
+from typing import Any, cast
 
-def test_health_and_ready():
-    with TestClient(app) as client:
+from fastapi.testclient import TestClient
+
+import capsule_brain.api.server as server
+from capsule_brain.core.capsule_engine import CapsuleEngine
+
+
+def test_health_and_ready() -> None:
+    with TestClient(server.app) as client:
         r = client.get("/healthz")
         assert r.status_code == 200 and r.json()["ok"] is True
         r = client.get("/ready")
         assert r.status_code == 200 and r.json()["ready"] is True
 
-def test_state_and_graph():
-    with TestClient(app) as client:
+def test_state_and_graph() -> None:
+    with TestClient(server.app) as client:
         r = client.get("/state/summary")
         assert r.status_code == 200
         js = r.json()
@@ -20,8 +25,8 @@ def test_state_and_graph():
         g = r.json()["graph"]
         assert g["nodes"] >= 2 and g["edges"] >= 1
 
-def test_metrics():
-    with TestClient(app) as client:
+def test_metrics() -> None:
+    with TestClient(server.app) as client:
         # hit a couple endpoints first
         client.get("/healthz")
         client.get("/ready")
@@ -31,3 +36,27 @@ def test_metrics():
         text = r.text
         assert "cb_http_requests_total" in text
         assert "cb_request_latency_seconds_bucket" in text
+
+
+def test_ask_accepts_multiple_payloads() -> None:
+    with TestClient(server.app) as client:
+        ready = client.get("/ready")
+        assert ready.status_code == 200
+        assert server.engine is not None
+        current_engine = cast(CapsuleEngine, server.engine)
+
+        def _post_and_check(payload: dict[str, Any], expected: str) -> None:
+            before = len(current_engine.memory)
+            response = client.post("/ask", **payload)
+            assert response.status_code == 200
+            body = response.json()
+            assert body["ack"] is True
+            assert len(current_engine.memory) == before + 1
+            assert current_engine.memory[-1]["content"] == expected
+
+        _post_and_check({"json": {"q": "json alias"}}, "json alias")
+        _post_and_check({"json": {"question": "json question"}}, "json question")
+        _post_and_check({"params": {"q": "query question"}}, "query question")
+
+        missing = client.post("/ask")
+        assert missing.status_code == 422

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,7 +56,17 @@ def test_ask_accepts_multiple_payloads() -> None:
 
         _post_and_check({"json": {"q": "json alias"}}, "json alias")
         _post_and_check({"json": {"question": "json question"}}, "json question")
-        _post_and_check({"params": {"q": "query question"}}, "query question")
+        _post_and_check({"data": {"q": "form question"}}, "form question")
+        _post_and_check(
+            {
+                "data": "plain text question",
+                "headers": {"content-type": "text/plain"},
+            },
+            "plain text question",
+        )
+        _post_and_check(
+            {"json": {}, "params": {"q": "query question"}}, "query question"
+        )
 
         missing = client.post("/ask")
         assert missing.status_code == 422


### PR DESCRIPTION
### **User description**
## Summary
- add an AskRequest model so /ask can accept JSON payloads while retaining the legacy query parameter fallback
- ensure the ask handler validates input, updates engine memory, and keeps the response structure intact
- extend API tests to cover JSON and query parameter submissions to /ask

## Testing
- PYTHONPATH=. pytest
- ruff check capsule_brain/api/server.py tests/test_api.py --fix
- PYTHONPATH=. mypy capsule_brain/api/server.py tests/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ca5f5200c4832dad74865c61287aa4


___

### **PR Type**
Enhancement


___

### **Description**
- Add JSON body support to `/ask` endpoint with `AskRequest` model

- Maintain backward compatibility with query parameter fallback

- Improve type annotations and error handling throughout API

- Add comprehensive tests for both JSON and query parameter inputs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Client Request"] --> B["AskRequest Model"]
  B --> C["Extract Question"]
  C --> D["Fallback to Query Param"]
  D --> E["Validate Input"]
  E --> F["Update Engine Memory"]
  F --> G["Return Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Add JSON body support and improve type safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

capsule_brain/api/server.py

<ul><li>Add <code>AskRequest</code> Pydantic model with question field and alias support<br> <li> Update <code>/ask</code> endpoint to accept both JSON body and query parameters<br> <li> Improve type annotations from <code>Dict</code> to <code>dict</code> and add return types<br> <li> Add proper error handling and engine validation with assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/dawsonblock/Liquid-Capsule-Brain/pull/23/files#diff-1cd17903dd1244a49a9f11ce2f07c6c7ba81041561a815d941e3fcb901fb2f67">+57/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Add comprehensive tests for ask endpoint variations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_api.py

<ul><li>Add comprehensive test for <code>/ask</code> endpoint with JSON and query <br>parameters<br> <li> Test both <code>q</code> alias and <code>question</code> field variations<br> <li> Verify engine memory updates and error handling for missing parameters<br> <li> Improve existing test type annotations</ul>


</details>


  </td>
  <td><a href="https://github.com/dawsonblock/Liquid-Capsule-Brain/pull/23/files#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79">+36/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

